### PR TITLE
feat: add watchlist destroy command

### DIFF
--- a/oshi-chan/Cargo.toml
+++ b/oshi-chan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oshi-chan"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oshi-chan/src/commands.rs
+++ b/oshi-chan/src/commands.rs
@@ -3,4 +3,5 @@ pub mod poll;
 pub mod version;
 pub mod watchlist_add;
 pub mod watchlist_delete;
+pub mod watchlist_destroy;
 pub mod watchlist_list;

--- a/oshi-chan/src/commands/introduce.rs
+++ b/oshi-chan/src/commands/introduce.rs
@@ -6,6 +6,7 @@ const COMMAND_LIST: &str = "
 !oshi watchlist list: list anime in the watchlist
 !oshi watchlist add <aniwave-id> <latest-episode>: add an anime to the watchlist
 !oshi watchlist delete <aniwave-id>: remove an anime from the watchlist
+!oshi watchlist destroy: clear the watchlist
 !oshi poll: force oshi to poll aniwave for new releases
 ";
 

--- a/oshi-chan/src/commands/watchlist_destroy.rs
+++ b/oshi-chan/src/commands/watchlist_destroy.rs
@@ -1,0 +1,17 @@
+use crate::PgPool;
+use pg_client::{ConnectionManager, PgConnection, Pool, PooledConnection};
+use serenity::{model::channel::Message, prelude::*};
+
+pub async fn exec(ctx: &Context, msg: &Message) {
+    let data: tokio::sync::RwLockReadGuard<TypeMap> = ctx.data.read().await;
+    let pool: &Pool<ConnectionManager<PgConnection>> = data.get::<PgPool>().unwrap();
+    let connection: &mut PooledConnection<ConnectionManager<PgConnection>> =
+        &mut pool.get().unwrap();
+
+    pg_client::destroy_watchlist(connection);
+
+    let content = "I just destroyed the watchlist!";
+    if let Err(why) = msg.channel_id.say(&ctx.http, content).await {
+        println!("version: error sending message: {:?}", why);
+    }
+}

--- a/oshi-chan/src/handler.rs
+++ b/oshi-chan/src/handler.rs
@@ -60,6 +60,9 @@ impl EventHandler for Handler {
                         }
                         commands::watchlist_delete::exec(&ctx, &msg, command_parts[3]).await;
                     }
+                    "destroy" => {
+                        commands::watchlist_destroy::exec(&ctx, &msg).await;
+                    }
                     "list" => {
                         commands::watchlist_list::exec(&ctx, &msg).await;
                     }

--- a/pg-client/src/lib.rs
+++ b/pg-client/src/lib.rs
@@ -57,3 +57,7 @@ pub fn delete_watchlist_entry(connection: &mut PgConnection, anime_id: &str) {
         .execute(connection)
         .unwrap();
 }
+
+pub fn destroy_watchlist(connection: &mut PgConnection) {
+    diesel::delete(watchlist).execute(connection).unwrap();
+}


### PR DESCRIPTION
## Summary

Adds `!oshi watchlist destroy`, which will clear the entire watchlist.

## Commentary

There was an aniwave.to service degradation that happened a few days ago, and I had to clear the watchlist to stop the bot from behaving strangely. This command would have been great to have at the time...

I also tend to clear the watchlist every season, so I think this will be pretty useful.